### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 !/ship/
 !/.gitignore
 /ship/output
+/config/sodium-options.json
 *.pyc


### PR DESCRIPTION
Unversioned sodium-options, as this is a video settings config specific to my client (and should not be included in any further commits).