### PR TITLE
Fix for Spyglass

### DIFF
--- a/patchouli_books/crucialguide/en_us/templates/crucial_kit_items.json
+++ b/patchouli_books/crucialguide/en_us/templates/crucial_kit_items.json
@@ -48,7 +48,7 @@
 		{
 			"type": "item",
 			"item": {
-				"item": "farsight_spyglasses:spyglass"
+				"item": "cavesandcliffs:spyglass"
 			},
 			"framed": true,
 			"x": 24,


### PR DESCRIPTION
Fixed reference to removed Farsight spyglass in guide book (replaced with Caves and Cliffs version).